### PR TITLE
[0.9]: Exceptions, Logging, Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Gemfile.lock
 *.gem
 *.rbc
 /.config

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Lint/NestedMethodDefinition:
   Exclude:
     - test/action_controller/serialization_test.rb
 
+Style/FrozenStringLiteralComment:
+  EnforcedStyle: always
+
 Style/StringLiterals:
   EnforcedStyle: single_quotes
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,6 +13,9 @@ Lint/NestedMethodDefinition:
   Exclude:
     - test/action_controller/serialization_test.rb
 
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
 Style/FrozenStringLiteralComment:
   EnforcedStyle: always
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in authorizable.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,2 @@
+# frozen_string_literal: true
 require 'bundler/gem_tasks'

--- a/lib/generators/operation/operation_generator.rb
+++ b/lib/generators/operation/operation_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class OperationGenerator < Rails::Generators::NamedBase
   # gives us file_name
   source_root File.expand_path('../templates', __FILE__)

--- a/lib/generators/policy/policy_generator.rb
+++ b/lib/generators/policy/policy_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class PolicyGenerator < Rails::Generators::NamedBase
   # gives us file_name
   source_root File.expand_path('../templates', __FILE__)

--- a/lib/generators/skinny_controller/skinny_controller_generator.rb
+++ b/lib/generators/skinny_controller/skinny_controller_generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SkinnyControllerGenerator < Rails::Generators::NamedBase
   # gives us file_name
   source_root File.expand_path('../templates', __FILE__)

--- a/lib/generators/skinny_controller/skinny_controller_generator.rb
+++ b/lib/generators/skinny_controller/skinny_controller_generator.rb
@@ -4,7 +4,8 @@ class SkinnyControllerGenerator < Rails::Generators::NamedBase
   source_root File.expand_path('../templates', __FILE__)
 
   def generate_layout
-    template 'skinny_controller.rb.erb', File.join('app/controllers', class_path, "#{file_name}_controller.rb")
+    template 'skinny_controller.rb.erb',
+      File.join('app/controllers', class_path, "#{file_name}_controller.rb")
   end
 
   def operation_name

--- a/lib/skinny_controllers.rb
+++ b/lib/skinny_controllers.rb
@@ -7,6 +7,7 @@ require 'active_support/core_ext/string/inflections'
 
 # files for this gem
 require 'skinny_controllers/default_verbs'
+require 'skinny_controllers/exceptions'
 require 'skinny_controllers/lookup/namespace'
 require 'skinny_controllers/lookup/controller'
 require 'skinny_controllers/lookup/model'
@@ -33,6 +34,32 @@ module SkinnyControllers
   #  SkinnyControllers.controller_namespace = 'API'
   #  # 'API::' would be removed from 'API::Namespace::ObjectNamesController'
   cattr_accessor :controller_namespace
+
+  class << self; attr_accessor :logger; end
+  self.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
+
+
+  # Allows integration of a search gem, like ransack.
+  # The scope of this proc is within an operation, so all operation
+  # instance variables will be available.
+  #
+  # - params
+  # - params_for_action
+  # - current_user
+  # - action
+  # - model_key
+  # - model_params
+  #
+  # @example
+  #   # config/initializers/skinny_controllers.rb
+  #   SkinnyControllers.search_proc = ->(association) {
+  #     association.ransack(params[:q]).result
+  #   }
+  cattr_accessor :search_proc do
+    lambda do |association|
+      association
+    end
+  end
 
   cattr_accessor :operations_suffix do
     'Operations'.freeze

--- a/lib/skinny_controllers.rb
+++ b/lib/skinny_controllers.rb
@@ -8,6 +8,7 @@ require 'active_support/core_ext/string/inflections'
 # files for this gem
 require 'skinny_controllers/default_verbs'
 require 'skinny_controllers/exceptions'
+require 'skinny_controllers/logging'
 require 'skinny_controllers/lookup/namespace'
 require 'skinny_controllers/lookup/controller'
 require 'skinny_controllers/lookup/model'
@@ -24,6 +25,8 @@ require 'skinny_controllers/diet'
 require 'skinny_controllers/version'
 
 module SkinnyControllers
+  include Logging
+
   POLICY_METHOD_SUFFIX = '?'.freeze
 
   # Tells the Diet what namespace of the controller
@@ -34,10 +37,6 @@ module SkinnyControllers
   #  SkinnyControllers.controller_namespace = 'API'
   #  # 'API::' would be removed from 'API::Namespace::ObjectNamesController'
   cattr_accessor :controller_namespace
-
-  class << self; attr_accessor :logger; end
-  self.logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
-
 
   # Allows integration of a search gem, like ransack.
   # The scope of this proc is within an operation, so all operation

--- a/lib/skinny_controllers.rb
+++ b/lib/skinny_controllers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # required gems
 require 'active_support'
 require 'active_support/core_ext/class'

--- a/lib/skinny_controllers/default_verbs.rb
+++ b/lib/skinny_controllers/default_verbs.rb
@@ -2,14 +2,14 @@
 module SkinnyControllers
   module DefaultVerbs
     # show
-    Read = 'Read'
+    Read = 'Read'.freeze
     # index
-    ReadAll = 'ReadAll'
+    ReadAll = 'ReadAll'.freeze
     # create
-    Create = 'Create'
+    Create = 'Create'.freeze
     # destroy
-    Delete = 'Delete'
+    Delete = 'Delete'.freeze
     # update
-    Update = 'Update'
+    Update = 'Update'.freeze
   end
 end

--- a/lib/skinny_controllers/default_verbs.rb
+++ b/lib/skinny_controllers/default_verbs.rb
@@ -1,14 +1,15 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module DefaultVerbs
     # show
-    Read = 'Read'.freeze
+    Read = 'Read'
     # index
-    ReadAll = 'ReadAll'.freeze
+    ReadAll = 'ReadAll'
     # create
-    Create = 'Create'.freeze
+    Create = 'Create'
     # destroy
-    Delete = 'Delete'.freeze
+    Delete = 'Delete'
     # update
-    Update = 'Update'.freeze
+    Update = 'Update'
   end
 end

--- a/lib/skinny_controllers/diet.rb
+++ b/lib/skinny_controllers/diet.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Diet
     extend ActiveSupport::Concern
@@ -16,7 +17,8 @@ module SkinnyControllers
       @operation ||= operation_class.new(
         current_user,
         params, params_for_action,
-        action_name, self.class.model_key)
+        action_name, self.class.model_key
+      )
     end
 
     # Assumes the operation name from the controller name
@@ -81,8 +83,8 @@ module SkinnyControllers
 
     def verb_for_action
       SkinnyControllers.action_map[action_name] ||
-      (action_name && action_name.classify) ||
-      SkinnyControllers.action_map['default']
+        (action_name && action_name.classify) ||
+        SkinnyControllers.action_map['default']
     end
   end
 end

--- a/lib/skinny_controllers/exceptions.rb
+++ b/lib/skinny_controllers/exceptions.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   class ModelNotFound < StandardError; end
   class DeniedByPolicy < StandardError; end

--- a/lib/skinny_controllers/exceptions.rb
+++ b/lib/skinny_controllers/exceptions.rb
@@ -1,0 +1,4 @@
+module SkinnyControllers
+  class ModelNotFound < StandardError; end
+  class DeniedByPolicy < StandardError; end
+end

--- a/lib/skinny_controllers/logging.rb
+++ b/lib/skinny_controllers/logging.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+module SkinnyControllers
+  module Logging
+    extend ActiveSupport::Concern
+
+    included do
+      self.logger = Logger.new
+    end
+
+    class Logger
+      attr_accessor :_logger
+      attr_accessor :_tag
+      def initialize
+        @_logger = ActiveSupport::TaggedLogging.new(ActiveSupport::Logger.new(STDOUT))
+        @_tag = 'skinny_controllers'
+      end
+
+      def warn(*args)
+        _logger.tagged(_tag) { _logger.warn(*args) }
+      end
+
+      def info(*args)
+        _logger.tagged(_tag) { _logger.info(*args) }
+      end
+    end
+
+    module ClassMethods
+      attr_accessor :logger
+    end
+  end
+end

--- a/lib/skinny_controllers/lookup/controller.rb
+++ b/lib/skinny_controllers/lookup/controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Lookup
     module Controller

--- a/lib/skinny_controllers/lookup/model.rb
+++ b/lib/skinny_controllers/lookup/model.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Lookup
     module Model

--- a/lib/skinny_controllers/lookup/namespace.rb
+++ b/lib/skinny_controllers/lookup/namespace.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Lookup
     module Namespace

--- a/lib/skinny_controllers/lookup/namespace.rb
+++ b/lib/skinny_controllers/lookup/namespace.rb
@@ -18,7 +18,7 @@ module SkinnyControllers
           current = (existing + [namespace]).join('::')
           begin
             Object.const_get(current)
-          rescue NameError => e
+          rescue NameError
             SkinnyControllers.logger.warn("Module #{namespace} not found, creating...")
             previous.const_set(namespace, Module.new)
           end

--- a/lib/skinny_controllers/lookup/namespace.rb
+++ b/lib/skinny_controllers/lookup/namespace.rb
@@ -18,6 +18,7 @@ module SkinnyControllers
           begin
             Object.const_get(current)
           rescue NameError => e
+            SkinnyControllers.logger.warn("Module #{namespace} not found, creating...")
             previous.const_set(namespace, Module.new)
           end
 

--- a/lib/skinny_controllers/lookup/operation.rb
+++ b/lib/skinny_controllers/lookup/operation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Lookup
     module Operation

--- a/lib/skinny_controllers/lookup/operation.rb
+++ b/lib/skinny_controllers/lookup/operation.rb
@@ -31,7 +31,13 @@ module SkinnyControllers
         default_operation = SkinnyControllers::Operation::Default
         namespace = Lookup::Operation.default_operation_namespace_for(model_name)
 
-        default = "#{namespace.name}::#{verb}".safe_constantize
+        operation_class_name = "#{namespace.name}::#{verb}"
+        default = operation_class_name.safe_constantize
+
+        unless default
+          SkinnyControllers.logger.warn("#{operation_class_name} not found. Creating default...")
+        end
+
         default || namespace.const_set(verb, default_operation.dup)
       end
 
@@ -40,7 +46,14 @@ module SkinnyControllers
         # binding.pry
         desired_namespace = namespace_from_model(model_name)
         parent_namespace = SkinnyControllers.operations_namespace
-        namespace = "#{parent_namespace}::#{desired_namespace}".safe_constantize
+
+        namespace_name = "#{parent_namespace}::#{desired_namespace}"
+        namespace = namespace_name.safe_constantize
+
+        unless namespace
+          SkinnyControllers.logger.warn("#{namespace_name} not found. Creating...")
+        end
+
         namespace || Namespace.create_namespace(desired_namespace)
       end
 

--- a/lib/skinny_controllers/lookup/policy.rb
+++ b/lib/skinny_controllers/lookup/policy.rb
@@ -8,6 +8,11 @@ module SkinnyControllers
       def class_from_model(name)
         policy_class_name = class_name_from_model(name)
         klass = policy_class_name.safe_constantize
+
+        unless klass
+          SkinnyControllers.logger.warn("#{policy_class_name} not found. Creating Default...")
+        end
+
         klass || define_policy_class(policy_class_name)
       end
 

--- a/lib/skinny_controllers/lookup/policy.rb
+++ b/lib/skinny_controllers/lookup/policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Lookup
     module Policy

--- a/lib/skinny_controllers/operation/base.rb
+++ b/lib/skinny_controllers/operation/base.rb
@@ -17,10 +17,24 @@ module SkinnyControllers
 
       attr_accessor :params, :current_user, :authorized_via_parent, :action, :params_for_action, :model_key
 
-      def self.run(current_user, params)
-        object = new(current_user, params)
-        object.run
+      class << self
+        def run(current_user, params)
+          object = new(current_user, params)
+          object.run
+        end
+
+        # To support the shorthand ruby/block syntax
+        # e.g.: MyOperation.()
+        alias_method :call, :run
       end
+
+      # To be overridden
+      def run; end;
+
+      # To support teh shorthand ruby/block syntax
+      # e.g.: MyOperation.new().()
+      alias_method :call, :run
+
 
       # @param [Model] current_user the logged in user
       # @param [Hash] controller_params the params hash raw from the controller

--- a/lib/skinny_controllers/operation/base.rb
+++ b/lib/skinny_controllers/operation/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Operation
     #
@@ -29,12 +30,11 @@ module SkinnyControllers
       end
 
       # To be overridden
-      def run; end;
+      def run; end
 
       # To support teh shorthand ruby/block syntax
       # e.g.: MyOperation.new().()
       alias_method :call, :run
-
 
       # @param [Model] current_user the logged in user
       # @param [Hash] controller_params the params hash raw from the controller
@@ -96,7 +96,8 @@ module SkinnyControllers
         @policy ||= policy_class.new(
           current_user,
           object,
-          authorized_via_parent: authorized_via_parent)
+          authorized_via_parent: authorized_via_parent
+        )
       end
 
       def allowed?

--- a/lib/skinny_controllers/operation/default.rb
+++ b/lib/skinny_controllers/operation/default.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Operation
     class Default < Base
@@ -45,7 +46,7 @@ module SkinnyControllers
       end
 
       def check_allowed!
-        raise DeniedByPolicy.new(action) unless allowed?
+        raise DeniedByPolicy, action unless allowed?
       end
     end
   end

--- a/lib/skinny_controllers/operation/default.rb
+++ b/lib/skinny_controllers/operation/default.rb
@@ -12,11 +12,14 @@ module SkinnyControllers
         #  - EventOperations::Destroy
         if creating?
           @model = model_class.new(model_params)
-          @model.save if allowed?
+
+          check_allowed!
+
+          @model.save
           return @model
         end
 
-        return unless allowed?
+        check_allowed!
 
         if updating?
           model.update(model_params)
@@ -39,6 +42,10 @@ module SkinnyControllers
 
       def destroying?
         action == 'destroy'
+      end
+
+      def check_allowed!
+        raise DeniedByPolicy.new(action) unless allowed?
       end
     end
   end

--- a/lib/skinny_controllers/operation/model_helpers.rb
+++ b/lib/skinny_controllers/operation/model_helpers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Operation
     module ModelHelpers
@@ -42,7 +43,7 @@ module SkinnyControllers
         unless @model_params
           model_params = (params_for_action[model_param_name] || params_for_action)
 
-          @model_params = (model_params == params) ? {} : model_params.symbolize_keys
+          @model_params = model_params == params ? {} : model_params.symbolize_keys
         end
 
         @model_params

--- a/lib/skinny_controllers/operation/model_helpers.rb
+++ b/lib/skinny_controllers/operation/model_helpers.rb
@@ -84,10 +84,9 @@ module SkinnyControllers
       def model_from_named_id(key, id)
         name = key.gsub(/_id$/, '')
         name = name.camelize
-        model_from_scope(
-          id: id,
-          type: name
-        )
+        association = model_from_scope(id: id, type: name)
+
+        SkinnyControllers.search_proc.call(association)
       end
 
       def model_from_scope(scope = params[:scope])

--- a/lib/skinny_controllers/policy/allow_all.rb
+++ b/lib/skinny_controllers/policy/allow_all.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Policy
     class AllowAll < Base

--- a/lib/skinny_controllers/policy/base.rb
+++ b/lib/skinny_controllers/policy/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Policy
     class Base

--- a/lib/skinny_controllers/policy/base.rb
+++ b/lib/skinny_controllers/policy/base.rb
@@ -19,22 +19,24 @@ module SkinnyControllers
       # @param [Array] args
       # @param [Proc] block
       def method_missing(method_name, *args, &block)
-        # if the method ends in a question mark, re-route to default
-        if method_name.to_s =~ /(.+)\?/
-          action = Regexp.last_match(1)
-          # alias destroy to delete
-          # TODO: this means that a destroy method, if defined,
-          #       will never be called.... good or bad?
-          #       should there be a difference between delete and destroy?
-          return send('delete?'.freeze) if action == 'destroy'.freeze
+        # unless the method ends in a question mark, re-route to default method_missing
+        return super unless method_name.to_s =~ /(.+)\?/
 
-          # we know that these methods don't take any parameters,
-          # so args and block can be ignored
-          SkinnyControllers.logger.warn("#{action} in policy #{self.class.name} was not found. Using :default?")
-          send(:default?)
-        else
-          super
-        end
+        action = Regexp.last_match(1)
+        # alias destroy to delete
+        # TODO: this means that a destroy method, if defined,
+        #       will never be called.... good or bad?
+        #       should there be a difference between delete and destroy?
+        return send('delete?'.freeze) if action == 'destroy'.freeze
+
+        # we know that these methods don't take any parameters,
+        # so args and block can be ignored
+        SkinnyControllers.logger.warn("#{action} in policy #{self.class.name} was not found. Using :default?")
+        send(:default?)
+      end
+
+      def respond_to_missing?(method_name, include_private = false)
+        method_name.to_s =~ /(.+)\?/ || super
       end
 
       # if a method is not defined for a particular verb or action,

--- a/lib/skinny_controllers/policy/base.rb
+++ b/lib/skinny_controllers/policy/base.rb
@@ -29,6 +29,7 @@ module SkinnyControllers
 
           # we know that these methods don't take any parameters,
           # so args and block can be ignored
+          SkinnyControllers.logger.warn("#{action} in policy #{self.class.name} was not found. Using :default?")
           send(:default?)
         else
           super

--- a/lib/skinny_controllers/policy/default.rb
+++ b/lib/skinny_controllers/policy/default.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Policy
     class Default < Base

--- a/lib/skinny_controllers/policy/deny_all.rb
+++ b/lib/skinny_controllers/policy/deny_all.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   module Policy
     class DenyAll < Base

--- a/lib/skinny_controllers/version.rb
+++ b/lib/skinny_controllers/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module SkinnyControllers
   VERSION = '0.9.0'.freeze
 end

--- a/lib/skinny_controllers/version.rb
+++ b/lib/skinny_controllers/version.rb
@@ -1,3 +1,3 @@
 module SkinnyControllers
-  VERSION = '0.8.7'.freeze
+  VERSION = '0.9.0'.freeze
 end

--- a/skinny_controllers.gemspec
+++ b/skinny_controllers.gemspec
@@ -1,4 +1,5 @@
 # -*- encoding: utf-8 -*-
+# frozen_string_literal: true
 
 # allows bundler to use the gemspec for dependencies
 lib = File.expand_path('../lib', __FILE__)

--- a/skinny_controllers.gemspec
+++ b/skinny_controllers.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.summary     = "SkinnyControllers-#{SkinnyControllers::VERSION}"
   s.description = 'An implementation of role-based policies and operations to help controllers lose weight.'
 
-  s.files        = Dir['CHANGELOG.md', 'LICENSE' 'MIT-LICENSE', 'README.md', 'lib/**/*']
+  s.files        = Dir['CHANGELOG.md', 'LICENSE', 'README.md', 'lib/**/*']
   s.require_path = 'lib'
 
   s.test_files = s.files.grep(%r{^(test|spec|features)/})

--- a/spec/integration/access_spec.rb
+++ b/spec/integration/access_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe 'Access' do

--- a/spec/integration/rails/crud_controller_spec.rb
+++ b/spec/integration/rails/crud_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe UsersController, type: :controller do

--- a/spec/integration/rails/custom_model_controller_spec.rb
+++ b/spec/integration/rails/custom_model_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe EventSummariesController, type: :controller do

--- a/spec/integration/rails/default_all_controller_spec.rb
+++ b/spec/integration/rails/default_all_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe UsersController, type: :controller do

--- a/spec/integration/rails/json_api_events_controller_spec.rb
+++ b/spec/integration/rails/json_api_events_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe JsonApiEventsController, type: :controller do

--- a/spec/integration/rails/json_api_spec.rb
+++ b/spec/integration/rails/json_api_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe JsonApiEventsController, type: :controller do

--- a/spec/integration/rails/load_path_spec.rb
+++ b/spec/integration/rails/load_path_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe 'definitions of operations and policies' do

--- a/spec/integration/rails/namespaced_controller_spec.rb
+++ b/spec/integration/rails/namespaced_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe ItemsController, type: :controller do

--- a/spec/integration/rails/namespaced_relationship_controller_spec.rb
+++ b/spec/integration/rails/namespaced_relationship_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe OtherItemsController, type: :controller do

--- a/spec/integration/rails/no_operations_controller_spec.rb
+++ b/spec/integration/rails/no_operations_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe NoOperationsController, type: :controller do
@@ -7,7 +8,7 @@ describe NoOperationsController, type: :controller do
 
   context 'show' do
     it 'gets the model - because the current_user is passed through the anonymous operation to the explicit policy' do
-      allow(controller).to receive(:current_user){ create(:user) }
+      allow(controller).to receive(:current_user) { create(:user) }
       no_operation = create(:no_operation)
 
       get :show, id: no_operation.id
@@ -20,10 +21,9 @@ describe NoOperationsController, type: :controller do
 
   context 'create' do
     it 'creates' do
-      expect{
+      expect do
         post :create, no_operation: {}
-      }.to change(NoOperation, :count).by(1)
-
+      end.to change(NoOperation, :count).by(1)
     end
   end
 end

--- a/spec/integration/rails/no_operations_controller_spec.rb
+++ b/spec/integration/rails/no_operations_controller_spec.rb
@@ -7,7 +7,8 @@ describe NoOperationsController, type: :controller do
   end
 
   context 'show' do
-    it 'gets the model - because the current_user is passed through the anonymous operation to the explicit policy' do
+    it 'gets the model - because the current_user is passed
+        through the anonymous operation to the explicit policy' do
       allow(controller).to receive(:current_user) { create(:user) }
       no_operation = create(:no_operation)
 

--- a/spec/integration/rails/operations/model_helpers_spec.rb
+++ b/spec/integration/rails/operations/model_helpers_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe EventOperations do

--- a/spec/integration/rails/operations/model_helpers_spec.rb
+++ b/spec/integration/rails/operations/model_helpers_spec.rb
@@ -19,7 +19,7 @@ describe EventOperations do
       expect(op).to_not receive(:model_from_named_id)
       expect(op).to_not receive(:model_from_id)
       expect(op).to_not receive(:model_from_params)
-      result = op.find_model
+      op.find_model
     end
   end
 

--- a/spec/integration/rails/requires_parent_controller_spec.rb
+++ b/spec/integration/rails/requires_parent_controller_spec.rb
@@ -34,7 +34,7 @@ describe RequiresParentController, type: :controller do
 
     it 'requires the parent id' do
       event = create(:event)
-      discount = create(:discount, event: event)
+      create(:discount, event: event)
 
       expect do
         get :index

--- a/spec/integration/rails/requires_parent_controller_spec.rb
+++ b/spec/integration/rails/requires_parent_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe RequiresParentController, type: :controller do

--- a/spec/integration/rails/scoped_resource_controller_spec.rb
+++ b/spec/integration/rails/scoped_resource_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe DiscountsController, type: :controller do

--- a/spec/integration/rails/single_resource_controller_spec.rb
+++ b/spec/integration/rails/single_resource_controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe EventsController, type: :controller do

--- a/spec/integration/rails/strong_parameters_spec.rb
+++ b/spec/integration/rails/strong_parameters_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails_helper'
 
 describe StrongParametersController, type: :controller do

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rails/all'
 
 require 'factory_girl'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'rubygems'
 require 'bundler/setup'
 

--- a/spec/support/example_operation.rb
+++ b/spec/support/example_operation.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Example
   class << self
     def find(*_args)

--- a/spec/support/fake_controller.rb
+++ b/spec/support/fake_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # 2cool4 ActionController::Base
 class FakeController
   # http://www.rubydoc.info/docs/rails/2.3.8/ActionController%2FBase%3Aaction_name

--- a/spec/support/operations/example_operations.rb
+++ b/spec/support/operations/example_operations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ExampleOperations
   class ReadAll < SkinnyControllers::Operation::Base
     def run

--- a/spec/support/policies/example_operation_policy.rb
+++ b/spec/support/policies/example_operation_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ExamplePolicy < SkinnyControllers::Policy::Base
   def read?
     object.is_accessible_to? user

--- a/spec/support/rails_app/Gemfile
+++ b/spec/support/rails_app/Gemfile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 source 'https://rubygems.org'
 
 # this file is pretty much only used for adding migrations

--- a/spec/support/rails_app/Rakefile
+++ b/spec/support/rails_app/Rakefile
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/spec/support/rails_app/app/controllers/application_controller.rb
+++ b/spec/support/rails_app/app/controllers/application_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.

--- a/spec/support/rails_app/app/controllers/discounts_controller.rb
+++ b/spec/support/rails_app/app/controllers/discounts_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class DiscountsController < ApplicationController
   include SkinnyControllers::Diet
 

--- a/spec/support/rails_app/app/controllers/event_summaries_controller.rb
+++ b/spec/support/rails_app/app/controllers/event_summaries_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class EventSummariesController < ApplicationController
   include SkinnyControllers::Diet
   self.model_class = Event

--- a/spec/support/rails_app/app/controllers/events_controller.rb
+++ b/spec/support/rails_app/app/controllers/events_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class EventsController < ApplicationController
   include SkinnyControllers::Diet
 

--- a/spec/support/rails_app/app/controllers/items_controller.rb
+++ b/spec/support/rails_app/app/controllers/items_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class ItemsController < ApplicationController
   include SkinnyControllers::Diet
   self.model_class = SuperItem::Item

--- a/spec/support/rails_app/app/controllers/json_api_events_controller.rb
+++ b/spec/support/rails_app/app/controllers/json_api_events_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class JsonApiEventsController < ApplicationController
   include SkinnyControllers::Diet
   self.model_class = Event

--- a/spec/support/rails_app/app/controllers/no_operations_controller.rb
+++ b/spec/support/rails_app/app/controllers/no_operations_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class NoOperationsController < ApplicationController
   include SkinnyControllers::Diet
 

--- a/spec/support/rails_app/app/controllers/other_items_controller.rb
+++ b/spec/support/rails_app/app/controllers/other_items_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class OtherItemsController < ApplicationController
   include SkinnyControllers::Diet
   self.model_class = SuperItem::OtherItem

--- a/spec/support/rails_app/app/controllers/requires_parent_controller.rb
+++ b/spec/support/rails_app/app/controllers/requires_parent_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class RequiresParentController < ApplicationController
   include SkinnyControllers::Diet
   self.model_class = Discount

--- a/spec/support/rails_app/app/controllers/strong_parameters_controller.rb
+++ b/spec/support/rails_app/app/controllers/strong_parameters_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class StrongParametersController < ApplicationController
   include SkinnyControllers::Diet
 

--- a/spec/support/rails_app/app/controllers/users_controller.rb
+++ b/spec/support/rails_app/app/controllers/users_controller.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class UsersController < ApplicationController
   include SkinnyControllers::Diet
 

--- a/spec/support/rails_app/app/models/discount.rb
+++ b/spec/support/rails_app/app/models/discount.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Discount < ActiveRecord::Base
   belongs_to :event
 end

--- a/spec/support/rails_app/app/models/event.rb
+++ b/spec/support/rails_app/app/models/event.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Event < ActiveRecord::Base
   belongs_to :user
   has_many :discounts

--- a/spec/support/rails_app/app/models/no_operation.rb
+++ b/spec/support/rails_app/app/models/no_operation.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class NoOperation < ActiveRecord::Base
 end

--- a/spec/support/rails_app/app/models/super_item.rb
+++ b/spec/support/rails_app/app/models/super_item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SuperItem < ActiveRecord::Base
   self.inheritance_column = 'item_type'
 

--- a/spec/support/rails_app/app/models/super_item/item.rb
+++ b/spec/support/rails_app/app/models/super_item/item.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class SuperItem::Item < SuperItem
 end

--- a/spec/support/rails_app/app/models/super_item/other_item.rb
+++ b/spec/support/rails_app/app/models/super_item/other_item.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class SuperItem::OtherItem < SuperItem
   belongs_to :super_item, foreign_key: :reference_id
 end

--- a/spec/support/rails_app/app/models/user.rb
+++ b/spec/support/rails_app/app/models/user.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class User < ActiveRecord::Base
   has_many :events
 

--- a/spec/support/rails_app/app/operations/discount_operations.rb
+++ b/spec/support/rails_app/app/operations/discount_operations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module DiscountOperations
   class Read < SkinnyControllers::Operation::Base
     def run

--- a/spec/support/rails_app/app/operations/event_operations/read.rb
+++ b/spec/support/rails_app/app/operations/event_operations/read.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module EventOperations
   class Read < SkinnyControllers::Operation::Base
     def run

--- a/spec/support/rails_app/app/operations/user_operations.rb
+++ b/spec/support/rails_app/app/operations/user_operations.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module UserOperations
   class Read < SkinnyControllers::Operation::Base
     def run

--- a/spec/support/rails_app/app/policies/event_policy.rb
+++ b/spec/support/rails_app/app/policies/event_policy.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 class EventPolicy < SkinnyControllers::Policy::Base
-  def read?(o = object)
+  def read?(_o = object)
     # for testing, in real life, this is implicit, and
     # the method does not even need to be defined
     true

--- a/spec/support/rails_app/app/policies/no_operation_policy.rb
+++ b/spec/support/rails_app/app/policies/no_operation_policy.rb
@@ -1,5 +1,5 @@
+# frozen_string_literal: true
 class NoOperationPolicy < SkinnyControllers::Policy::Base
-
   def read?
     user.present?
   end

--- a/spec/support/rails_app/app/policies/user_policy.rb
+++ b/spec/support/rails_app/app/policies/user_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class UserPolicy < SkinnyControllers::Policy::DenyAll
   # exceptions to the DenyAll rule may be defined here
 

--- a/spec/support/rails_app/config/application.rb
+++ b/spec/support/rails_app/config/application.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require File.expand_path('../boot', __FILE__)
 
 require 'rails/all'

--- a/spec/support/rails_app/config/boot.rb
+++ b/spec/support/rails_app/config/boot.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../../Gemfile', __FILE__)
 
 require 'bundler/setup' # Set up gems listed in the Gemfile.

--- a/spec/support/rails_app/config/environment.rb
+++ b/spec/support/rails_app/config/environment.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Load the Rails application.
 require File.expand_path('../application', __FILE__)
 

--- a/spec/support/rails_app/config/environments/development.rb
+++ b/spec/support/rails_app/config/environments/development.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/support/rails_app/config/environments/test.rb
+++ b/spec/support/rails_app/config/environments/test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/support/rails_app/config/initializers/assets.rb
+++ b/spec/support/rails_app/config/initializers/assets.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/spec/support/rails_app/config/initializers/cookies_serializer.rb
+++ b/spec/support/rails_app/config/initializers/cookies_serializer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.action_dispatch.cookies_serializer = :json

--- a/spec/support/rails_app/config/initializers/filter_parameter_logging.rb
+++ b/spec/support/rails_app/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/spec/support/rails_app/config/initializers/session_store.rb
+++ b/spec/support/rails_app/config/initializers/session_store.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_rails_app_session'

--- a/spec/support/rails_app/config/initializers/wrap_parameters.rb
+++ b/spec/support/rails_app/config/initializers/wrap_parameters.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/spec/support/rails_app/config/routes.rb
+++ b/spec/support/rails_app/config/routes.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Rails.application.routes.draw do
   resources :users
 

--- a/spec/support/rails_app/factories.rb
+++ b/spec/support/rails_app/factories.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 FactoryGirl.define do
   factory :user do
   end

--- a/spec/support/rails_app/factory_girl.rb
+++ b/spec/support/rails_app/factory_girl.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods
 

--- a/spec/support/user.rb
+++ b/spec/support/user.rb
@@ -1,2 +1,3 @@
+# frozen_string_literal: true
 class TestUser
 end

--- a/spec/unit/diet_spec.rb
+++ b/spec/unit/diet_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SkinnyControllers::Diet do

--- a/spec/unit/lookup/controller_spec.rb
+++ b/spec/unit/lookup/controller_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SkinnyControllers::Lookup::Controller do

--- a/spec/unit/lookup/model_lookup_spec.rb
+++ b/spec/unit/lookup/model_lookup_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SkinnyControllers::Lookup::Model do

--- a/spec/unit/lookup/namespace_spec.rb
+++ b/spec/unit/lookup/namespace_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SkinnyControllers::Lookup::Namespace do

--- a/spec/unit/lookup/operation_lookup_spec.rb
+++ b/spec/unit/lookup/operation_lookup_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SkinnyControllers::Lookup::Operation do

--- a/spec/unit/lookup/policy_lookup_spec.rb
+++ b/spec/unit/lookup/policy_lookup_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SkinnyControllers::Lookup::Policy do

--- a/spec/unit/operation/operation_spec.rb
+++ b/spec/unit/operation/operation_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe ExampleOperations::Read do

--- a/spec/unit/policy/_all_spec.rb
+++ b/spec/unit/policy/_all_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SkinnyControllers::Policy::DenyAll do

--- a/spec/unit/policy/base_spec.rb
+++ b/spec/unit/policy/base_spec.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'spec_helper'
 
 describe SkinnyControllers::Policy::Base do


### PR DESCRIPTION
### Closes

- [x] #22 - search gem integration
- [x] #26 - logging

#### Breaking
- [x] #19 - Exceptions upon failed policy check
- [x] #13 - change default `allowed?` check on `create` to require the `@model`

#### To be discussed later
- [ ] #25 - remove `accesible_to_scope`

This brings the version to `0.9.0`