### PR TITLE
Move qualified_name lookup in a method

### DIFF
--- a/lib/skinny_controllers/lookup/ensure_existence.rb
+++ b/lib/skinny_controllers/lookup/ensure_existence.rb
@@ -113,8 +113,8 @@ module SkinnyControllers
     # @return [Array<Constant, Boolean>]
     def lookup_helper(qualified_name, sender)
       # Validate the name.
-      name_flag, klass = qualified_name.blank?
-      return klass, true if name_flag
+      name_flag = qualified_name.blank?
+      return klass, name_flag if name_flag # return nil as the klass value
 
       # Return if the constant exists.
       klass = qualified_name.safe_constantize

--- a/lib/skinny_controllers/lookup/namespace.rb
+++ b/lib/skinny_controllers/lookup/namespace.rb
@@ -17,7 +17,6 @@ module SkinnyControllers
         namespaces.each do |namespace|
           current = (existing + [namespace]).join('::')
           begin
-            # binding.pry
             Object.const_get(current)
           rescue NameError
             SkinnyControllers.logger.warn("Module #{namespace} not found, creating...")


### PR DESCRIPTION
With this pull request we will refactor `#ensure_existence` a bit, by moving `qualified_name` lookup in a seperate method.